### PR TITLE
Increase nonce length to 32 bytes in OCSP validation test

### DIFF
--- a/src/WebEid.Security/Validator/Ocsp/OcspRequestBuilder.cs
+++ b/src/WebEid.Security/Validator/Ocsp/OcspRequestBuilder.cs
@@ -94,7 +94,7 @@ namespace WebEid.Security.Validator.Ocsp
 
         private void AddNonce(OcspReqGenerator builder)
         {
-            this.Nonce = new byte[8];
+            this.Nonce = new byte[32];
 
             using (var rndGenerator = RandomNumberGenerator.Create())
             {


### PR DESCRIPTION
Ticket WE2-819

Signed-off-by: Lauris Kaplinski <lauris.kaplinski@raulwalter.com>
