### PR TITLE
Nonce support was added to EstEID 2015

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ internal class FileReader
     }
 }
 ```
-Then copy the trusted certificates, for example `ESTEID-SK_2015.cer` and `ESTEID2018.cer`, to `Certificates` and load the certificates as follows:
+Then copy the trusted certificates, for example `ESTEID2018.cer`, to `Certificates` and load the certificates as follows:
 
 ```cs
 ...
@@ -362,7 +362,7 @@ The following additional configuration options are available in `AuthTokenValida
 - `WithDesignatedOcspServiceConfiguration(DesignatedOcspServiceConfiguration serviceConfiguration)` – activates the provided designated OCSP responder service configuration for user certificate revocation check with OCSP. The designated service is only used for checking the status of the certificates whose issuers are supported by the service, for other certificates the default AIA extension service access location will be used. See configuration examples in tests.
 - `WithOcspRequestTimeout(TimeSpan ocspRequestTimeout)` – sets both the connection and response timeout of user certificate revocation check OCSP requests. Default is 5 seconds.
 - `WithDisallowedCertificatePolicies(params string[] policies)` – adds the given policies to the list of disallowed user certificate policies. In order for the user certificate to be considered valid, it must not contain any policies present in this list. Contains the Estonian Mobile-ID policies by default as it must not be possible to authenticate with a Mobile-ID certificate when an eID smart card is expected.
-- `WithNonceDisabledOcspUrls(params Uri[] urls)` – adds the given URLs to the list of OCSP URLs for which the nonce protocol extension will be disabled. Some OCSP services don't support the nonce extension. Contains the ESTEID-2015 OCSP URL by default.
+- `WithNonceDisabledOcspUrls(params Uri[] urls)` – adds the given URLs to the list of OCSP URLs for which the nonce protocol extension will be disabled. Some OCSP services don't support the nonce extension.
 
 Extended configuration example:  
 

--- a/src/WebEid.Security.Tests/TestUtils/OcspServiceMaker.cs
+++ b/src/WebEid.Security.Tests/TestUtils/OcspServiceMaker.cs
@@ -49,7 +49,7 @@ namespace WebEid.Security.Tests.TestUtils
 
         public static OcspServiceProvider GetDesignatedOcspServiceProvider(string ocspServiceAccessLocation) => new(GetDesignatedOcspServiceConfiguration(true, ocspServiceAccessLocation), GetAiaOcspServiceConfiguration());
 
-        private static AiaOcspServiceConfiguration GetAiaOcspServiceConfiguration() => new(new List<Uri> { OcspUrls.AiaEsteid2015, TestEsteid2015 }, TrustedCaCertificates);
+        private static AiaOcspServiceConfiguration GetAiaOcspServiceConfiguration() => new(new List<Uri> { TestEsteid2015 }, TrustedCaCertificates);
 
         public static DesignatedOcspServiceConfiguration GetDesignatedOcspServiceConfiguration() => GetDesignatedOcspServiceConfiguration(true, TestOcspAccessLocation);
 
@@ -58,7 +58,7 @@ namespace WebEid.Security.Tests.TestUtils
         private static DesignatedOcspServiceConfiguration GetDesignatedOcspServiceConfiguration(bool doesSupportNonce, string ocspServiceAccessLocation) => new(
                 new Uri(ocspServiceAccessLocation),
                 DotNetUtilities.FromX509Certificate(Certificates.GetTestSkOcspResponder2020()),
-                TrustedCaCertificates.Select(c => DotNetUtilities.FromX509Certificate(c)).ToList(),
+                TrustedCaCertificates.Select(DotNetUtilities.FromX509Certificate).ToList(),
                 doesSupportNonce);
     }
 }

--- a/src/WebEid.Security/Validator/AuthTokenValidationConfiguration.cs
+++ b/src/WebEid.Security/Validator/AuthTokenValidationConfiguration.cs
@@ -26,7 +26,6 @@ namespace WebEid.Security.Validator
     using System.Collections.ObjectModel;
     using System.Linq;
     using System.Security.Cryptography.X509Certificates;
-    using Ocsp;
     using Ocsp.Service;
     using Util;
 
@@ -65,7 +64,7 @@ namespace WebEid.Security.Validator
             });
 
         // Disable OCSP nonce extension for EstEID 2015 cards by default.
-        public List<Uri> NonceDisabledOcspUrls { get; } = new List<Uri> { OcspUrls.AiaEsteid2015 };
+        public List<Uri> NonceDisabledOcspUrls { get; } = new List<Uri> { };
 
 
         private static void Validate(Uri siteOrigin, List<X509Certificate2> trustedCaCertificates, TimeSpan ocspRequestTimeout)

--- a/src/WebEid.Security/Validator/Ocsp/OcspUrls.cs
+++ b/src/WebEid.Security/Validator/Ocsp/OcspUrls.cs
@@ -29,10 +29,6 @@ namespace WebEid.Security.Validator.Ocsp
 
     public static class OcspUrls
     {
-#pragma warning disable S1075 // URIs should not be hardcoded
-        public static readonly Uri AiaEsteid2015 = new Uri("http://aia.sk.ee/esteid2015"); //NOSONAR
-#pragma warning restore S1075 // URIs should not be hardcoded
-
         /// <summary>
         /// Returns the OCSP responder <see cref="Uri">Uri</see> or null if it doesn't have one.
         /// </summary>


### PR DESCRIPTION
+ All ID-Card certificates are expired in this service

WE2-839

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Please update Signed-off-by info and read the common contributing guidelines
before you continue https://github.com/web-eid/.github/blob/master/CONTRIBUTING.md!
-->

Signed-off-by: Raul Metsma <raul@metsma.ee>
