### PR TITLE
fix: use system time in OcspResponseValidator.validateCertificateStatusUpdateTime()

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,8 @@ The following additional configuration options are available in `AuthTokenValida
 - `WithOcspRequestTimeout(TimeSpan ocspRequestTimeout)` – sets both the connection and response timeout of user certificate revocation check OCSP requests. Default is 5 seconds.
 - `WithDisallowedCertificatePolicies(params string[] policies)` – adds the given policies to the list of disallowed user certificate policies. In order for the user certificate to be considered valid, it must not contain any policies present in this list. Contains the Estonian Mobile-ID policies by default as it must not be possible to authenticate with a Mobile-ID certificate when an eID smart card is expected.
 - `WithNonceDisabledOcspUrls(params Uri[] urls)` – adds the given URLs to the list of OCSP URLs for which the nonce protocol extension will be disabled. Some OCSP services don't support the nonce extension.
-
+- `WithAllowedOcspResponseTimeSkew(TimeSpan allowedTimeSkew)` - sets the allowed time skew for OCSP response's `thisUpdate` and `nextUpdate` times to allow discrepancies between the system clock and the OCSP responder's clock or revocation updates that are not published in real time. The default allowed time skew is 15 minutes. The relatively long default is specifically chosen to account for one particular OCSP responder that used CRLs for authoritative revocation info, these CRLs were updated every 15 minutes.
+- `WithMaxOcspResponseThisUpdateAge(TimeSpan maxThisUpdateAge)` - sets the maximum age for the OCSP response's `thisUpdate` time before it is considered too old to rely on. The default maximum age is 2 minutes.
 Extended configuration example:  
 
 ```cs  

--- a/src/WebEid.Security.Tests/TestUtils/AuthTokenValidators.cs
+++ b/src/WebEid.Security.Tests/TestUtils/AuthTokenValidators.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright © 2020-2024 Estonian Information System Authority
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -61,6 +61,9 @@ namespace WebEid.Security.Tests.TestUtils
             GetAuthTokenValidatorBuilder(TokenOriginUrl, GetCaCertificates())
                 .WithDisallowedCertificatePolicies(EstIdemiaPolicy)
                 .Build();
+
+        public static AuthTokenValidatorBuilder GetDefaultAuthTokenValidatorBuilder() =>
+            GetAuthTokenValidatorBuilder(TokenOriginUrl, GetCaCertificates());
 
         private static AuthTokenValidatorBuilder GetAuthTokenValidatorBuilder(string uri, X509Certificate2[] certificates) =>
             new AuthTokenValidatorBuilder()

--- a/src/WebEid.Security.Tests/TestUtils/DateTimeExtensions.cs
+++ b/src/WebEid.Security.Tests/TestUtils/DateTimeExtensions.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright © 2020-2024 Estonian Information System Authority
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -22,6 +22,7 @@
 namespace WebEid.Security.Tests.TestUtils
 {
     using System;
+    using Org.BouncyCastle.Asn1;
 
     internal static class DateTimeExtensions
     {
@@ -29,5 +30,7 @@ namespace WebEid.Security.Tests.TestUtils
         {
             return dt.AddTicks(-dt.Ticks % TimeSpan.TicksPerSecond);
         }
+
+        internal static DerGeneralizedTime ToDerGenTime(this DateTime dateTime) => new(dateTime);
     }
 }

--- a/src/WebEid.Security.Tests/Validator/AuthTokenValidationConfigurationTests.cs
+++ b/src/WebEid.Security.Tests/Validator/AuthTokenValidationConfigurationTests.cs
@@ -39,7 +39,7 @@ namespace WebEid.Security.Tests.Validator
         {
             var configuration = new AuthTokenValidationConfiguration();
             Assert.Throws<ArgumentNullException>(() => configuration.Validate())
-                .WithMessage("Value cannot be null. (Parameter 'siteOrigin')");
+                .WithMessage("Value cannot be null. (Parameter 'SiteOrigin')");
         }
 
         [Test]
@@ -72,7 +72,34 @@ namespace WebEid.Security.Tests.Validator
             configuration.TrustedCaCertificates.Add(new X509Certificate2(Array.Empty<byte>()));
             configuration.OcspRequestTimeout = TimeSpan.Zero;
             Assert.Throws<ArgumentOutOfRangeException>(() => configuration.Validate())
-                .WithMessage("OCSP request timeout must be greater than zero (Parameter 'ocspRequestTimeout')");
+                .WithMessage("OCSP request timeout must be greater than zero (Parameter 'timeSpan')");
+        }
+
+        [Test]
+        public void WhenInvalidOcspResponseTimeSkewThenValidationFails()
+        {
+            var builderWithInvalidOcspResponseTimeSkew =
+                AuthTokenValidators.GetDefaultAuthTokenValidatorBuilder().WithAllowedOcspResponseTimeSkew(TimeSpan.FromMinutes(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => builderWithInvalidOcspResponseTimeSkew.Build())
+                .HasMessageStartingWith("Allowed OCSP response time-skew must be greater than zero");
+        }
+
+        [Test]
+        public void WhenInvalidMaxOcspResponseThisUpdateAgeThenValidationFails()
+        {
+            var builderWithInvalidMaxOcspResponseThisUpdateAge =
+                AuthTokenValidators.GetDefaultAuthTokenValidatorBuilder().WithMaxOcspResponseThisUpdateAge(TimeSpan.Zero);
+            Assert.Throws<ArgumentOutOfRangeException>(() => builderWithInvalidMaxOcspResponseThisUpdateAge.Build())
+                .HasMessageStartingWith("Max OCSP response thisUpdate age must be greater than zero");
+        }
+
+        [Test]
+        public void WhenInvalidOcspResponseTimeoutThenValidationFails()
+        {
+            var builderWithInvalidOcspResponseTimeout =
+                AuthTokenValidators.GetDefaultAuthTokenValidatorBuilder().WithOcspRequestTimeout(TimeSpan.FromMinutes(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => builderWithInvalidOcspResponseTimeout.Build())
+                .HasMessageStartingWith("OCSP request timeout must be greater than zero");
         }
 
         [Test]

--- a/src/WebEid.Security.Tests/Validator/AuthTokenValidatorBuilderTest.cs
+++ b/src/WebEid.Security.Tests/Validator/AuthTokenValidatorBuilderTest.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright © 2020-2024 Estonian Information System Authority
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -36,7 +36,7 @@ namespace WebEid.Security.Tests.Validator
         [Test]
         public void WhenOriginMissingThenBuildingFails() =>
             Assert.Throws<ArgumentNullException>(() => this.builder.Build())
-                .WithMessage("Value cannot be null. (Parameter 'siteOrigin')");
+                .WithMessage("Value cannot be null. (Parameter 'SiteOrigin')");
 
         [Test]
         public void WhenRootCertificateAuthorityMissingThenBuildingFails()

--- a/src/WebEid.Security/Validator/AuthTokenValidator.cs
+++ b/src/WebEid.Security/Validator/AuthTokenValidator.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright © 2020-2024 Estonian Information System Authority
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -192,6 +192,8 @@ namespace WebEid.Security.Validator
                     new SubjectCertificateNotRevokedValidator(certTrustedValidator,
                         this.ocspClient,
                         this.ocspServiceProvider,
+                        this.configuration.AllowedOcspResponseTimeSkew,
+                        this.configuration.MaxOcspResponseThisUpdateAge,
                         this.logger));
         }
     }

--- a/src/WebEid.Security/Validator/AuthTokenValidatorBuilder.cs
+++ b/src/WebEid.Security/Validator/AuthTokenValidatorBuilder.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright © 2020-2024 Estonian Information System Authority
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -107,6 +107,36 @@ namespace WebEid.Security.Validator
         {
             this.configuration.OcspRequestTimeout = ocspRequestTimeout;
             this.logger?.LogDebug("OCSP request timeout set to {0}.", ocspRequestTimeout);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the allowed time skew for OCSP response's thisUpdate and nextUpdate times.
+        /// This parameter is used to allow discrepancies between the system clock and the OCSP responder's clock,
+        /// which may occur due to clock drift, network delays or revocation updates that are not published in real time.
+        /// This is an optional configuration parameter, the default is 15 minutes.
+        /// The relatively long default is specifically chosen to account for one particular OCSP responder that used
+        /// CRLs for authoritative revocation info, these CRLs were updated every 15 minutes.
+        /// </summary>
+        /// <param name="allowedTimeSkew">The allowed time skew</param>
+        /// <returns>the builder instance for method chaining</returns>
+        public AuthTokenValidatorBuilder WithAllowedOcspResponseTimeSkew(TimeSpan allowedTimeSkew)
+        {
+            this.configuration.AllowedOcspResponseTimeSkew = allowedTimeSkew;
+            this.logger?.LogDebug("Allowed OCSP response time skew set to {0}.", allowedTimeSkew);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the maximum age of the OCSP response's thisUpdate time before it is considered too old.
+        /// This is an optional configuration parameter, the default is 2 minutes.
+        /// </summary>
+        /// <param name="maxThisUpdateAge">The maximum age of the OCSP response's thisUpdate time</param>
+        /// <returns>the builder instance for method chaining</returns>
+        public AuthTokenValidatorBuilder WithMaxOcspResponseThisUpdateAge(TimeSpan maxThisUpdateAge)
+        {
+            this.configuration.MaxOcspResponseThisUpdateAge = maxThisUpdateAge;
+            this.logger?.LogDebug("Maximum OCSP response thisUpdate age set to {0}.", maxThisUpdateAge);
             return this;
         }
 

--- a/src/WebEid.Security/Validator/CertValidators/SubjectCertificateNotRevokedValidator.cs
+++ b/src/WebEid.Security/Validator/CertValidators/SubjectCertificateNotRevokedValidator.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright © 2020-2024 Estonian Information System Authority
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -41,15 +41,22 @@ namespace WebEid.Security.Validator.CertValidators
         private readonly OcspServiceProvider ocspServiceProvider;
         private readonly ILogger logger;
 
+        private readonly TimeSpan allowedOcspTimeSkew;
+        private readonly TimeSpan maxOcspResponseThisUpdateAge;
+
         public SubjectCertificateNotRevokedValidator(SubjectCertificateTrustedValidator trustValidator,
             IOcspClient ocspClient,
             OcspServiceProvider ocspServiceProvider,
+            TimeSpan allowedOcspTimeSkew,
+            TimeSpan maxOcspResponseThisUpdateAge,
             ILogger logger = null)
         {
             this.trustValidator = trustValidator;
             this.ocspClient = ocspClient;
             this.ocspServiceProvider = ocspServiceProvider;
             this.logger = logger;
+            this.allowedOcspTimeSkew = allowedOcspTimeSkew;
+            this.maxOcspResponseThisUpdateAge = maxOcspResponseThisUpdateAge;
         }
 
         /// <summary>
@@ -157,7 +164,7 @@ namespace WebEid.Security.Validator.CertValidators
             //      be available about the status of the certificate (nextUpdate) is
             //      greater than the current time.
 
-            OcspResponseValidator.ValidateCertificateStatusUpdateTime(certStatusResponse, producedAt);
+            OcspResponseValidator.ValidateCertificateStatusUpdateTime(certStatusResponse, allowedOcspTimeSkew, maxOcspResponseThisUpdateAge);
 
             // Now we can accept the signed response as valid and validate the certificate status.
             OcspResponseValidator.ValidateOcspResponseStatus(certStatusResponse);


### PR DESCRIPTION
Fixes the same issue that was fixed in Java with [this pull request](https://github.com/web-eid/web-eid-authtoken-validation-java/pull/55).

WE2-868

Signed-off-by: Mihkel Kivisild mihkel.kivisild@cgi.com
